### PR TITLE
fix: progress bar should span the whole container

### DIFF
--- a/modules/core/css/components/Status.less
+++ b/modules/core/css/components/Status.less
@@ -36,6 +36,7 @@
         right: 0;
         left: 0;
         min-width: 10em;
+        max-width: none;
         height: 5px;
         border: 0;
         background-color: transparent;


### PR DESCRIPTION
Currently, the OOUI progress bar is not spanning the whole width of the container because of the `max-width: 50em` rule from OOUI. By unsetting the `max-width`, it is now spanning the container correctly.

https://github.com/user-attachments/assets/541f6bdc-baa5-4150-b188-7c914cebe7a7

