### PR TITLE
feat: separate navigation control from actions

### DIFF
--- a/modules/core/Viewport.js
+++ b/modules/core/Viewport.js
@@ -120,7 +120,7 @@ class Viewport extends EventEmitter {
          *
          * @type {Controls.ExtraViewControls?}
          */
-        this.viewControls = this.addControl( Viewport.anchors.topRight, new Controls.ExtraViewControls( this.map ) );
+        this.viewControls = this.addControl( Viewport.anchors.bottomRight, new Controls.ExtraViewControls( this.map ) );
         /**
          * Fullscreen mode switcher control.
          *
@@ -241,7 +241,7 @@ class Viewport extends EventEmitter {
             markerZoomScaleFactor: 1.8,
             // Zoom control
             zoomControlOptions: {
-                position: 'topright',
+                position: 'bottomright',
                 zoomInTitle: mw.msg( 'datamap-control-zoom-in' ),
                 zoomOutTitle: mw.msg( 'datamap-control-zoom-out' )
             },

--- a/modules/core/css/components/ControlsLayout.less
+++ b/modules/core/css/components/ControlsLayout.less
@@ -2,37 +2,12 @@
     > .leaflet-top.leaflet-left {
         bottom: 10%;
         display: flex;
-        max-width: 100%;
+        max-width: ~'calc( 100% - 84px )'; // Reserve space for top right button
         box-sizing: border-box;
         padding-right: 10px;
     }
 
     .ext-datamaps-control-group {
         display: flex;
-    }
-
-    @media screen and ( max-width: calc( @width-breakpoint-tablet * 0.8 ) ) {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-
-        .leaflet-top {
-            position: unset;
-        }
-
-        .leaflet-top.leaflet-right {
-            display: flex;
-            flex-wrap: wrap;
-            align-items: start;
-            justify-content: center;
-            margin-left: 10px;
-        }
-
-        .leaflet-control-zoom,
-        .ext-datamaps-control-viewcontrols {
-            display: flex;
-            flex-wrap: wrap;
-            order: -1;
-        }
     }
 }

--- a/modules/core/css/components/Legend.less
+++ b/modules/core/css/components/Legend.less
@@ -1,6 +1,6 @@
 .ext-datamaps-container-legend {
     display: grid;
-    width: 27em;
+    max-width: 100%;
     height: 100%;
     align-content: start;
     grid-template-columns: 100%;


### PR DESCRIPTION
- Refactor and simplify responsive handling
- Move all map navigation control to bottom right

https://github.com/user-attachments/assets/70dab044-6181-4c4a-81d2-3a6359162bb7

On a side-note, is there a specific reason on having the top right actions button aligned horizontally? It can be made vertical to save some space for the search and filter cards in smaller viewport.

