### PR TITLE
fix: popup button styles should apply to anchor instead of li

### DIFF
--- a/modules/core/css/components/Popups.less
+++ b/modules/core/css/components/Popups.less
@@ -87,14 +87,17 @@
         list-style: none;
 
         li {
+            margin-bottom: 0;
+        }
+
+        a {
             padding: 0.2em 0.5em;
             border: 1px solid #7776;
             border-radius: 4px;
-            margin-bottom: 0;
+            text-decoration: none;
             transition: background @transition-duration-base;
 
             &:hover {
-                border-radius: 2px;
                 background: #a0a7aa54;
             }
         }


### PR DESCRIPTION
Currently the button styles for the popup button is applied on the `<li>` element.
That makes the actual clickable button slightly smaller than the styles and the hover state.

https://github.com/user-attachments/assets/0f61c741-d384-4387-8d52-91a8a525df49

