### PR TITLE
fix: deprecate OOUI icon module

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -81,7 +81,7 @@
 		},
 
 		"ext.datamaps.icons": {
-			"class": "ResourceLoaderOOUIIconPackModule",
+			"class": "MediaWiki\\ResourceLoader\\OOUIIconPackModule",
 			"icons": [
 				"exitFullscreen",
 				"fullScreen",
@@ -225,7 +225,7 @@
 		},
 
 		"ext.datamaps.ve.icons": {
-			"class": "ResourceLoaderOOUIIconPackModule",
+			"class": "MediaWiki\\ResourceLoader\\OOUIIconPackModule",
 			"icons": [
 				"mapPin",
 				"trash",


### PR DESCRIPTION
Hard deprecated since MediaWiki 1.42 but available on 1.39+ 