### PR TITLE
feat: use a more accurate way to hide zoom button for touch devices

### DIFF
--- a/modules/core/css/components/ControlsLayout.less
+++ b/modules/core/css/components/ControlsLayout.less
@@ -10,4 +10,11 @@
     .ext-datamaps-control-group {
         display: flex;
     }
+
+    /* Hide zoom button only on touch devices */
+    .leaflet-control-zoom {
+        @media (hover: none) and (pointer: coarse) {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
The media query `@media (hover: none) and (pointer: coarse)` should be able to target touch devices only.

Related: #288