### PR TITLE
fix: popup button should respect popup padding

### DIFF
--- a/modules/core/css/components/Popups.less
+++ b/modules/core/css/components/Popups.less
@@ -82,7 +82,7 @@
     .ext-datamaps-popup-tools {
         display: flex;
         flex-wrap: wrap;
-        margin: 8px -2px -7px;
+        margin: 8px 0 0;
         gap: 0.5em;
         list-style: none;
 
@@ -91,6 +91,7 @@
         }
 
         a {
+            display: block;
             padding: 0.2em 0.5em;
             border: 1px solid #7776;
             border-radius: 4px;


### PR DESCRIPTION
- Set `display:block` instead of `display:inline` in the `<a>` element so that it aligns according to the button instead of just the text
- Reset the negative margin of button so that it is consistent with the popup padding

| Before  | After |
| ------------- | ------------- |
| <img width="337" alt="image" src="https://github.com/user-attachments/assets/262690e3-7325-4760-afed-ad73d060a649">  | <img width="376" alt="image" src="https://github.com/user-attachments/assets/85fd0176-92bc-4673-9b14-af65d6a89b9a"> |

