### PR TITLE
feat: use GridLayer to render tiles

### DIFF
--- a/includes/Rendering/EmbedConfigGenerator.php
+++ b/includes/Rendering/EmbedConfigGenerator.php
@@ -181,13 +181,14 @@ class EmbedConfigGenerator {
             $out['aa'] = 1;
             // Translate all tiles into overlays
             $tileOffset = CoordinateSystem::normalisePoint( $spec->getTilePlacementOffset() ?? [ 0, 0 ], $coordOrder );
+            $out['tileOffset'] = $tileOffset;
             $tileSize = CoordinateSystem::normalisePoint( $spec->getTileSize(), $coordOrder );
             $out['tileSize'] = $tileSize;
             $pixelated = $spec->isPixelated();
             $spec->iterateTiles( function ( MapBackgroundTileSpec $tile ) use (
-                &$out, &$tileOffset, $coordOrder, $pixelated
+                &$out, $coordOrder, $pixelated
             ) {
-                $out['tiles'][] = $this->convertTile( $tile, $tileOffset, $coordOrder, $pixelated );
+                $out['tiles'][] = $this->convertTile( $tile, $coordOrder, $pixelated );
             } );
         }
         if ( $spec->hasOverlays() ) {
@@ -238,20 +239,13 @@ class EmbedConfigGenerator {
 
     private function convertTile(
         MapBackgroundTileSpec $spec,
-        array $tileOffset,
         int $coordOrder,
         bool $pixelated
     ) {
         $result = [];
 
-        $position = CoordinateSystem::normalisePoint( $spec->getPlacementLocation(), $coordOrder );
-        $position = [
-            $position[0] + $tileOffset[0],
-            $position[1] + $tileOffset[1]
-        ];
-
         $result['image'] = DataMapFileUtils::getRequiredFile( $spec->getImageName() )->getURL();
-        $result['position'] = $position;
+        $result['position'] =CoordinateSystem::normalisePoint( $spec->getPlacementLocation(), $coordOrder );
         $result['aa'] = 1;
         if ( $pixelated ) {
             $result['pixelated'] = true;

--- a/includes/Rendering/EmbedConfigGenerator.php
+++ b/includes/Rendering/EmbedConfigGenerator.php
@@ -182,11 +182,12 @@ class EmbedConfigGenerator {
             // Translate all tiles into overlays
             $tileOffset = CoordinateSystem::normalisePoint( $spec->getTilePlacementOffset() ?? [ 0, 0 ], $coordOrder );
             $tileSize = CoordinateSystem::normalisePoint( $spec->getTileSize(), $coordOrder );
+            $out['tileSize'] = $tileSize;
             $pixelated = $spec->isPixelated();
             $spec->iterateTiles( function ( MapBackgroundTileSpec $tile ) use (
-                &$out, &$tileOffset, &$tileSize, $coordOrder, $pixelated
+                &$out, &$tileOffset, $coordOrder, $pixelated
             ) {
-                $out['overlays'][] = $this->convertBackgroundTile( $tile, $tileOffset, $tileSize, $coordOrder, $pixelated );
+                $out['tiles'][] = $this->convertTile( $tile, $tileOffset, $coordOrder, $pixelated );
             } );
         }
         if ( $spec->hasOverlays() ) {
@@ -235,23 +236,22 @@ class EmbedConfigGenerator {
         return $result;
     }
 
-    private function convertBackgroundTile(
+    private function convertTile(
         MapBackgroundTileSpec $spec,
         array $tileOffset,
-        array $tileSize,
         int $coordOrder,
         bool $pixelated
     ) {
         $result = [];
 
-        $at = CoordinateSystem::normalisePoint( $spec->getPlacementLocation(), $coordOrder );
-        $at = [
-            [ $at[0] * $tileSize[0] + $tileOffset[0], $at[1] * $tileSize[1] + $tileOffset[1] ],
-            [ ( $at[0] + 1 ) * $tileSize[0] + $tileOffset[0], ( $at[1] + 1 ) * $tileSize[1] + $tileOffset[1] ]
+        $position = CoordinateSystem::normalisePoint( $spec->getPlacementLocation(), $coordOrder );
+        $position = [
+            $position[0] + $tileOffset[0],
+            $position[1] + $tileOffset[1]
         ];
 
         $result['image'] = DataMapFileUtils::getRequiredFile( $spec->getImageName() )->getURL();
-        $result['at'] = $at;
+        $result['position'] = $position;
         $result['aa'] = 1;
         if ( $pixelated ) {
             $result['pixelated'] = true;

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -53,6 +53,13 @@ class Background extends EventEmitter {
         this.image = config.image || null;
 
         /**
+         * Tile offset
+         *
+         * @type {array?}
+         */
+        this.tileOffset = config.tileOffset || null;
+
+        /**
          * Tile size
          *
          * @type {array?}
@@ -98,7 +105,7 @@ class Background extends EventEmitter {
             results.push( this._constructMainLayer() );
         }
         if ( this._tilesConfigs ) {
-            results.push( this._constructTiles( this._tilesConfigs, this.tileSize ) );
+            results.push( this._constructTiles( this._tilesConfigs, this.tileOffset, this.tileSize ) );
         }
         if ( this._overlayConfigs ) {
             for ( const config of this._overlayConfigs ) {
@@ -128,7 +135,7 @@ class Background extends EventEmitter {
         );
     }
 
-    _constructTiles( tiles, tileSize ) {
+    _constructTiles( tiles, offset, size ) {
         const Leaflet = Util.getLeaflet();
 
         const getImageUrlByPosition = ( position ) => {
@@ -148,14 +155,14 @@ class Background extends EventEmitter {
             createTile: function( coords ) {
                 // FIXME: Set coord order from config
                 const position = [
-                    coords.x,
-                    coords.y
+                    offset[0] + coords.x,
+                    offset[1] + coords.y
                 ];
                 const tile = Leaflet.DomUtil.create( 'canvas', 'leaflet-tile' );
                 tile.setAttribute( 'src', getImageUrlByPosition( position ) );
 
-                tile.width = tileSize[ 0 ];
-                tile.height = tileSize[ 1 ];
+                tile.width = size[ 0 ];
+                tile.height = size[ 1 ];
 
                 const ctx = tile.getContext( '2d' );
                 const imgSrc = getImageUrlByPosition( position );

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -153,10 +153,9 @@ class Background extends EventEmitter {
 
         const dataMapsTile = Leaflet.GridLayer.extend( {
             createTile: function( coords ) {
-                // FIXME: Set coord order from config
                 const position = [
-                    offset[0] + coords.x,
-                    offset[1] + coords.y
+                    offset[0] + coords.y,
+                    offset[1] + coords.x
                 ];
                 const tile = Leaflet.DomUtil.create( 'canvas', 'leaflet-tile' );
                 tile.setAttribute( 'src', getImageUrlByPosition( position ) );

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -149,7 +149,7 @@ class Background extends EventEmitter {
             if ( matchedImage ) {
                 return matchedImage;
             }
-        }
+        };
 
         const dataMapsTile = Leaflet.GridLayer.extend( {
             createTile: function( coords ) {

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -153,9 +153,6 @@ class Background extends EventEmitter {
                     coords.y
                 ];
                 const tile = Leaflet.DomUtil.create( 'canvas', 'leaflet-tile' );
-                if ( this.isPixelated ) {
-                    tile.classList.add( 'ext-datamaps-pixelated-image' );
-                }
                 tile.setAttribute( 'src', getImageUrlByPosition( position ) );
 
                 tile.width = tileSize[ 0 ];
@@ -175,8 +172,14 @@ class Background extends EventEmitter {
                 return tile;
             }
         } );
-        console.log( this.map.config.crs );
-        return new Leaflet.GridLayer.DataMapsTile();
+        console.log( this.map.config );
+        return new Leaflet.GridLayer.DataMapsTile( {
+            className: this.isPixelated ? 'ext-datamaps-pixelated-image' : undefined,
+            maxZoom: this.map.config.zoom.max,
+            minZoom: this.map.config.zoom.min,
+            maxNativeZoom: this.map.config.zoom.max,
+            minNativeZoom: this.map.config.zoom.min
+        } );
     }
 
 

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -138,17 +138,17 @@ class Background extends EventEmitter {
     _constructTiles( tiles, offset, size ) {
         const Leaflet = Util.getLeaflet();
 
+        const positionImageMap = tiles.reduce( ( map, tile ) => {
+            const [ x, y ] = tile.position;
+            map[ `${x},${y}` ] = tile.image;
+            return map;
+        }, {} );
+
         const getImageUrlByPosition = ( position ) => {
-            // Loop through each tile object
-            for ( const tile of tiles ) {
-                // Check if the position of the current tile matches the provided position
-                if ( JSON.stringify( tile.position ) === JSON.stringify( position ) ) {
-                    // Return the image URL if positions match
-                    return tile.image;
-                }
+            const matchedImage = positionImageMap[ `${position[0]},${position[1]}`];
+            if ( matchedImage ) {
+                return matchedImage;
             }
-            // Return null if no matching position is found
-            return null;
         }
 
         const dataMapsTile = Leaflet.GridLayer.extend( {

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -130,7 +130,6 @@ class Background extends EventEmitter {
 
     _constructTiles( tiles, tileSize ) {
         const Leaflet = Util.getLeaflet();
-        console.log( tiles );
 
         const getImageUrlByPosition = ( position ) => {
             // Loop through each tile object
@@ -145,7 +144,7 @@ class Background extends EventEmitter {
             return null;
         }
 
-        Leaflet.GridLayer.DataMapsTile = Leaflet.GridLayer.extend( {
+        const dataMapsTile = Leaflet.GridLayer.extend( {
             createTile: function( coords ) {
                 // FIXME: Set coord order from config
                 const position = [
@@ -172,8 +171,8 @@ class Background extends EventEmitter {
                 return tile;
             }
         } );
-        console.log( this.map.config );
-        return new Leaflet.GridLayer.DataMapsTile( {
+
+        return new dataMapsTile( {
             className: this.isPixelated ? 'ext-datamaps-pixelated-image' : undefined,
             maxZoom: this.map.config.zoom.max,
             minZoom: this.map.config.zoom.min,

--- a/modules/core/Background.js
+++ b/modules/core/Background.js
@@ -152,7 +152,10 @@ class Background extends EventEmitter {
                     coords.x,
                     coords.y
                 ];
-                const tile = Leaflet.DomUtil.create('canvas', 'leaflet-tile');
+                const tile = Leaflet.DomUtil.create( 'canvas', 'leaflet-tile' );
+                if ( this.isPixelated ) {
+                    tile.classList.add( 'ext-datamaps-pixelated-image' );
+                }
                 tile.setAttribute( 'src', getImageUrlByPosition( position ) );
 
                 tile.width = tileSize[ 0 ];
@@ -172,6 +175,7 @@ class Background extends EventEmitter {
                 return tile;
             }
         } );
+        console.log( this.map.config.crs );
         return new Leaflet.GridLayer.DataMapsTile();
     }
 


### PR DESCRIPTION
Probably need more work. Other than the issue below, it is working better than I thought.
It might be worth it to convert the base background into a single tile too.

Current issues:
- Zoom is not working correctly
- Position/Coordinate is not working correctly. 
  - Center of DataMaps is not center of the rendered tiles (try clicking the center button)
  - Coordinates display does not match image resolutions
  - GridLayer starts rendering at exactly [0,512] when it is a 2x2 256px tile grid, not sure why
- ~Coordinate order has not been taken into consideration~
- Need some linting, not sure what you are using for the project